### PR TITLE
Ignore partials and helpers by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 
 ### Added
-- [Your feature here!]
+- Added `ignoreHelpers` option to skip automatic lookup/bundling of helpers
 
 ## [1.5.0] - 2017-04-20
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ The following query (or config) options are supported:
  - *debug*: Shows trace information to help debug issues (e.g. resolution of helpers).
  - *partialDirs*: Defines additional directories to be searched for partials. Allows partials to be defined in a directory and used globally without relative paths. See [example](https://github.com/altano/handlebars-loader/tree/master/examples/partialDirs)
  - *preventIndent*: Prevent partials from being indented inside their parent template.
- - *ignorePartials*: Prevents partial references from being fetched and bundled. Useful for manually loading partials at runtime
+ - *ignorePartials*: Prevents partial references from being fetched and bundled. Useful for manually loading partials at runtime.
+ - *ignoreHelpers*: Prevents helper references from being fetched and bundled. Useful for manually loading helpers at runtime.
  - *compat*: Enables recursive field lookup for Mustache compatibility. See the Handlebars.js [documentation](https://github.com/wycats/handlebars.js#differences-between-handlebarsjs-and-mustache) for more information.
  - *config*: Tells the loader where to look in the webpack config for configurations for this loader. Defaults to `handlebarsLoader`.
  - *config.partialResolver* You can specify a function to use for resolving partials. To do so, add to your webpack config:

--- a/index.js
+++ b/index.js
@@ -235,15 +235,20 @@ module.exports = function(source) {
     var resolveUnclearStuffIterator = function(stuff, unclearStuffCallback) {
       if (foundUnclearStuff[stuff]) return unclearStuffCallback();
       var request = referenceToRequest(stuff.substr(1), 'unclearStuff');
-      resolve(request, 'unclearStuff', function(err, result) {
-        if (!err && result) {
-          knownHelpers[stuff.substr(1)] = true;
-          foundHelpers[stuff] = result;
-          needRecompile = true;
-        }
-        foundUnclearStuff[stuff] = true;
+
+      if (query.ignoreHelpers) {
         unclearStuffCallback();
-      });
+      } else {
+        resolve(request, 'unclearStuff', function(err, result) {
+          if (!err && result) {
+            knownHelpers[stuff.substr(1)] = true;
+            foundHelpers[stuff] = result;
+            needRecompile = true;
+          }
+          foundUnclearStuff[stuff] = true;
+          unclearStuffCallback();
+        });
+      }
     };
 
     var defaultPartialResolver = function defaultPartialResolver(request, callback){
@@ -291,25 +296,29 @@ module.exports = function(source) {
       if (foundHelpers[helper]) return helperCallback();
       var request = referenceToRequest(helper.substr(1), 'helper');
 
-      var defaultHelperResolver = function(request, callback){
-        return resolve(request, 'helper', callback);
-      };
-
-      var helperResolver = query.helperResolver || defaultHelperResolver;
-
-      helperResolver(request, function(err, result) {
-        if (!err && result) {
-          knownHelpers[helper.substr(1)] = true;
-          foundHelpers[helper] = result;
-          needRecompile = true;
-          return helperCallback();
-        }
-
-        // We don't return an error: we just fail to resolve the helper.
-        // This is b/c Handlebars calls nameLookup with type=helper for non-helper
-        // template options, e.g. something that comes from the template data.
+      if (query.ignoreHelpers) {
         helperCallback();
-      });
+      } else {
+        var defaultHelperResolver = function(request, callback){
+          return resolve(request, 'helper', callback);
+        };
+
+        var helperResolver = query.helperResolver || defaultHelperResolver;
+
+        helperResolver(request, function(err, result) {
+          if (!err && result) {
+            knownHelpers[helper.substr(1)] = true;
+            foundHelpers[helper] = result;
+            needRecompile = true;
+            return helperCallback();
+          }
+
+          // We don't return an error: we just fail to resolve the helper.
+          // This is b/c Handlebars calls nameLookup with type=helper for non-helper
+          // template options, e.g. something that comes from the template data.
+          helperCallback();
+        });
+      }
     };
 
     var doneResolving = function(err) {

--- a/index.js
+++ b/index.js
@@ -23,7 +23,10 @@ function getLoaderConfig(loaderContext) {
   var configKey = query.config || 'handlebarsLoader';
   var config = loaderContext.options[configKey] || {};
   delete query.config;
-  return assign({}, config, query);
+  return assign({
+    ignorePartials: true,
+    ignoreHelpers: true,
+  }, config, query);
 }
 
 module.exports = function(source) {


### PR DESCRIPTION
Same idea as using `ignorePartials`. Adding the same functionality to helpers so they may be configured completely at runtime without trying to resolve references.